### PR TITLE
DROP8 - feedback fixes 

### DIFF
--- a/app/src/main/java/com/example/taskyapplication/agenda/presentation/components/AgendaDeleteComponents.kt
+++ b/app/src/main/java/com/example/taskyapplication/agenda/presentation/components/AgendaDeleteComponents.kt
@@ -28,9 +28,9 @@ import com.example.taskyapplication.ui.theme.TaskyTypography
 
 @Composable
 fun AgendaItemDeleteTextButton(
+    itemToDelete: String,
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
-    itemToDelete: String,
     isEnabled: Boolean = false
 ) {
     Column(
@@ -64,10 +64,10 @@ fun AgendaItemDeleteTextButton(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DeleteItemBottomSheet(
+    itemToDelete: String,
     modifier: Modifier = Modifier,
     onDeleteTask: () -> Unit = {},
     onCancelDelete: () -> Unit = {},
-    itemToDelete: String
 ) {
     ModalBottomSheet(
         modifier = modifier,

--- a/app/src/main/java/com/example/taskyapplication/agenda/presentation/components/AgendaDeleteComponents.kt
+++ b/app/src/main/java/com/example/taskyapplication/agenda/presentation/components/AgendaDeleteComponents.kt
@@ -14,9 +14,11 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -68,7 +70,8 @@ fun AgendaItemDeleteTextButton(
 fun DeleteItemBottomSheet(
     modifier: Modifier = Modifier,
     onDeleteTask: () -> Unit = {},
-    onCancelDelete: () -> Unit = {}
+    onCancelDelete: () -> Unit = {},
+    itemToDelete: String
 ) {
     ModalBottomSheet(
         modifier = modifier,
@@ -101,12 +104,12 @@ fun DeleteItemBottomSheet(
                         .fillMaxWidth()
                         .padding(vertical = 16.dp),
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceEvenly
+                    horizontalArrangement = Arrangement.spacedBy(space = 16.dp)
                 ) {
                     OutlinedButton(
                         modifier = Modifier
                             .height(52.dp)
-                            .width(156.dp),
+                            .weight(1f),
                         border = BorderStroke(
                             width = 1.dp,
                             color = taskyColors.onSurfaceVariant,
@@ -117,12 +120,12 @@ fun DeleteItemBottomSheet(
                             contentColor = taskyColors.onSurface,
                         )
                     ) {
-                        Text(text = stringResource(android.R.string.cancel))
+                        Text(text = stringResource(android.R.string.cancel).uppercase())
                     }
                     OutlinedButton(
                         modifier = Modifier
                             .height(52.dp)
-                            .width(156.dp),
+                            .weight(1f),
                         border = BorderStroke(
                             width = 1.dp,
                             color = taskyColors.error,
@@ -133,7 +136,7 @@ fun DeleteItemBottomSheet(
                             contentColor = taskyColors.onPrimary,
                         )
                     ) {
-                        Text(text = stringResource(R.string.delete_text_button))
+                        Text(text = stringResource(R.string.delete_text_button, itemToDelete.uppercase()))
                     }
                 }
             }
@@ -153,5 +156,7 @@ fun DeleteButtonPreview() {
 @Preview(showBackground = true)
 @Composable
 fun DeleteBottomSheetPreview() {
-    DeleteItemBottomSheet()
+    DeleteItemBottomSheet(
+        itemToDelete = "Task"
+    )
 }

--- a/app/src/main/java/com/example/taskyapplication/agenda/presentation/components/AgendaDeleteComponents.kt
+++ b/app/src/main/java/com/example/taskyapplication/agenda/presentation/components/AgendaDeleteComponents.kt
@@ -6,19 +6,15 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
-import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -108,7 +104,6 @@ fun DeleteItemBottomSheet(
                 ) {
                     OutlinedButton(
                         modifier = Modifier
-                            .height(52.dp)
                             .weight(1f),
                         border = BorderStroke(
                             width = 1.dp,
@@ -120,11 +115,13 @@ fun DeleteItemBottomSheet(
                             contentColor = taskyColors.onSurface,
                         )
                     ) {
-                        Text(text = stringResource(android.R.string.cancel).uppercase())
+                        Text(
+                            modifier = Modifier.padding(vertical = 12.dp),
+                            text = stringResource(android.R.string.cancel).uppercase()
+                        )
                     }
                     OutlinedButton(
                         modifier = Modifier
-                            .height(52.dp)
                             .weight(1f),
                         border = BorderStroke(
                             width = 1.dp,
@@ -136,7 +133,10 @@ fun DeleteItemBottomSheet(
                             contentColor = taskyColors.onPrimary,
                         )
                     ) {
-                        Text(text = stringResource(R.string.delete_text_button, itemToDelete.uppercase()))
+                        Text(
+                            modifier = Modifier.padding(vertical = 12.dp),
+                            text = stringResource(R.string.delete_text_button, itemToDelete.uppercase())
+                        )
                     }
                 }
             }


### PR DESCRIPTION
Addresses feedback about fixed width and height applied to buttons in the Delete bottom sheet: #29 

#30 discusses not using a state object and instead passing individual properties into the Composables: I haven't addressed this yet, so the state object is still being used to represent the editable values (shown in #31) . 

I removed the use of `Resources` for the `ReminderOptions` enum, but I included the Strings as constant values for now. I'm still working through that (update shown in #31)

New version of Delete bottom sheet without fixed width and height: 
<img width="304" alt="delete-bottom-sheet" src="https://github.com/user-attachments/assets/ae93998e-6c86-4da0-a667-205e4a3f5bfa" />

